### PR TITLE
Refactor if-then to ternary in app-error-handler.service.ts

### DIFF
--- a/src/app/core/services/app-error-handler.service.ts
+++ b/src/app/core/services/app-error-handler.service.ts
@@ -23,14 +23,9 @@ export class AppErrorHandler extends ErrorHandler {
 
     const notifier = this.injector.get(SnackBarService);
     let message: string;
-
-    if (error instanceof HttpErrorResponse) {
-      // Server Error
-      message = error.message;
-    } else {
-      // Client Error
-      message = serializeError(error).message;
-    }
+    
+    // Server Error : Client Error
+    message = (error instanceof HttpErrorResponse) ? error.message : serializeError(error).message;
 
     notifier.show({
       message,


### PR DESCRIPTION
I noticed that this was flagged as an anti-pattern on deepsource.io and wanted to practice making a PR.